### PR TITLE
bug: Erpd 39 delete array splicing

### DIFF
--- a/src/components/CategoriesComponent.vue
+++ b/src/components/CategoriesComponent.vue
@@ -197,7 +197,7 @@ export default defineComponent({
       axios.delete('http://localhost:8080/categories/' + id)
         .then(res => {
           const storedIndex = this.categories.map(x => x.categoryId).indexOf(id)
-          this.categories.splice(storedIndex)
+          this.categories.splice(storedIndex, 1)
         })
         .catch(error => {
           console.log('deleteCategories() failed')

--- a/src/components/ProductsComponent.vue
+++ b/src/components/ProductsComponent.vue
@@ -239,7 +239,7 @@ export default defineComponent({
       axios.delete('http://localhost:8080/products/' + code)
         .then(res => {
           const storedIndex = this.products.map(x => x.barCode).indexOf(code)
-          this.products.splice(storedIndex)
+          this.products.splice(storedIndex, 1)
         })
         .catch(error => {
           console.log('deleteProduct() failed')

--- a/src/components/SuppliersComponent.vue
+++ b/src/components/SuppliersComponent.vue
@@ -184,12 +184,12 @@ export default defineComponent({
           alert('Supplier cannot be updated. Reason being: ' + error.response.data.message)
         })
     },
-    
+
     deleteSupplier (name) {
       axios.delete('http://localhost:8080/suppliers/' + name)
         .then(res => {
           const storedIndex = this.suppliers.map(s => s.supplierName).indexOf(name)
-          this.suppliers.splice(storedIndex)
+          this.suppliers.splice(storedIndex, 1)
         })
         .catch(error => {
           console.log('deleteSupplier() failed')


### PR DESCRIPTION
Fixed issue when deleting, all rows of the tables after the one selected would disappear until the page was reloaded